### PR TITLE
Refactor: Improve Dockerfile with best practices

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,38 @@
-FROM ubuntu:latest
-MAINTAINER xxradar "xxadar@radarhack.com"
-RUN apt-get update && apt-get install -y openssl && apt-get -y install ca-certificates
+# Use a specific version of Ubuntu for reproducibility
+FROM ubuntu:22.04
+
+# Set maintainer information using LABEL
+LABEL maintainer="xxradar <xxadar@radarhack.com>"
+
+# Update package lists, install necessary packages, and clean up in a single layer
+RUN apt-get update && \
+    apt-get install -y openssl ca-certificates && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Create a non-root user and group for security
+RUN addgroup --system appgroup && adduser --system --ingroup appgroup appuser
+
+# Set the working directory
 WORKDIR /scripts
-COPY tlssan_scan.sh tlssan_scan.sh
+
+# Copy the scanner script into the image
+COPY tlssan_scan.sh /scripts/tlssan_scan.sh
+
+# Ensure the script is executable (though COPY preserves permissions, this is explicit)
+RUN chmod +x /scripts/tlssan_scan.sh
+
+# Download and run Aqua MicroScanner
 ADD https://get.aquasec.com/microscanner /
 RUN chmod +x /microscanner
 ARG token
-RUN /microscanner ${token} --continue-on-failure 
-RUN echo "No vulnerabilities!"
+# Run MicroScanner; --continue-on-failure allows build to proceed even if issues are found
+RUN /microscanner ${token} --continue-on-failure
+# Remove MicroScanner after use
 RUN rm -rf /microscanner
+
+# Switch to the non-root user before setting the entrypoint
+USER appuser
+
+# Set the entrypoint for the container
 ENTRYPOINT ["/scripts/tlssan_scan.sh"]


### PR DESCRIPTION
This commit updates the Dockerfile with several improvements:

- Base Image: Changed from 'ubuntu:latest' to 'ubuntu:22.04' for more reproducible builds.
- Maintainer: Replaced deprecated 'MAINTAINER' instruction with 'LABEL maintainer'.
- Package Installation: Combined apt-get operations into a single RUN layer and included apt cache cleanup to reduce image size.
- Non-Root User: Implemented running the application as a non-root user ('appuser') for enhanced security.
- Clarity: Removed misleading 'RUN echo "No vulnerabilities!"' line.
- Readability: Added comments for better understanding of Dockerfile steps.

The Aqua MicroScanner integration remains functionally the same but benefits from the overall structural improvements to the Dockerfile. The image was successfully built with these changes.